### PR TITLE
Added button & item overlay color parameters

### DIFF
--- a/lib/dropdown_button2.dart
+++ b/lib/dropdown_button2.dart
@@ -109,7 +109,6 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
     required this.enableFeedback,
     this.itemSplashColor,
     this.itemHighlightColor,
-    this.itemOverlayColor,
     this.customItemsHeights,
   });
 
@@ -121,7 +120,6 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
   final bool enableFeedback;
   final Color? itemSplashColor;
   final Color? itemHighlightColor;
-  final MaterialStateColor? itemOverlayColor;
   final List<double>? customItemsHeights;
 
   @override
@@ -208,7 +206,6 @@ class _DropdownMenuItemButtonState<T>
         onFocusChange: _handleFocusChange,
         splashColor: widget.itemSplashColor,
         highlightColor: widget.itemHighlightColor,
-        overlayColor: widget.itemOverlayColor,
         child: Container(
           color:
               _isSelectedItem ? widget.route.selectedItemHighlightColor : null,
@@ -1208,8 +1205,8 @@ class DropdownButton2<T> extends StatefulWidget {
   /// The highlight color of the button's InkWell
   final Color? buttonHighlightColor;
 
-  //The overlay color of the button's Inkwell
-  final MaterialStateColor? buttonOverlayColor;
+  /// The overlay color of the button's Inkwell
+  final MaterialStateProperty<Color?>? buttonOverlayColor;
 
   /// The padding of menu items
   final EdgeInsetsGeometry? itemPadding;
@@ -1969,6 +1966,7 @@ class DropdownButtonFormField2<T> extends FormField<T> {
     int? buttonElevation,
     Color? buttonSplashColor,
     Color? buttonHighlightColor,
+    MaterialStateProperty<Color?>? buttonOverlayColor,
     EdgeInsetsGeometry? itemPadding,
     Color? itemSplashColor,
     Color? itemHighlightColor,
@@ -2084,6 +2082,7 @@ class DropdownButtonFormField2<T> extends FormField<T> {
                         buttonElevation: buttonElevation,
                         buttonSplashColor: buttonSplashColor,
                         buttonHighlightColor: buttonHighlightColor,
+                        buttonOverlayColor: buttonOverlayColor,
                         itemPadding: itemPadding,
                         itemSplashColor: itemSplashColor,
                         itemHighlightColor: itemHighlightColor,

--- a/lib/dropdown_button2.dart
+++ b/lib/dropdown_button2.dart
@@ -109,6 +109,7 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
     required this.enableFeedback,
     this.itemSplashColor,
     this.itemHighlightColor,
+    this.itemOverlayColor,
     this.customItemsHeights,
   });
 
@@ -120,6 +121,7 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
   final bool enableFeedback;
   final Color? itemSplashColor;
   final Color? itemHighlightColor;
+  final MaterialStateColor? itemOverlayColor;
   final List<double>? customItemsHeights;
 
   @override
@@ -206,6 +208,7 @@ class _DropdownMenuItemButtonState<T>
         onFocusChange: _handleFocusChange,
         splashColor: widget.itemSplashColor,
         highlightColor: widget.itemHighlightColor,
+        overlayColor: widget.itemOverlayColor,
         child: Container(
           color:
               _isSelectedItem ? widget.route.selectedItemHighlightColor : null,
@@ -1062,6 +1065,7 @@ class DropdownButton2<T> extends StatefulWidget {
     this.buttonElevation,
     this.buttonSplashColor,
     this.buttonHighlightColor,
+    this.buttonOverlayColor,
     this.itemPadding,
     this.itemSplashColor,
     this.itemHighlightColor,
@@ -1142,6 +1146,7 @@ class DropdownButton2<T> extends StatefulWidget {
     this.buttonElevation,
     this.buttonSplashColor,
     this.buttonHighlightColor,
+    this.buttonOverlayColor,
     this.itemPadding,
     this.itemSplashColor,
     this.itemHighlightColor,
@@ -1202,6 +1207,9 @@ class DropdownButton2<T> extends StatefulWidget {
 
   /// The highlight color of the button's InkWell
   final Color? buttonHighlightColor;
+
+  //The overlay color of the button's Inkwell
+  final MaterialStateColor? buttonOverlayColor;
 
   /// The padding of menu items
   final EdgeInsetsGeometry? itemPadding;
@@ -1891,6 +1899,7 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>>
               Theme.of(context).focusColor,
           splashColor: widget.buttonSplashColor,
           highlightColor: widget.buttonHighlightColor,
+          overlayColor: widget.buttonOverlayColor,
           enableFeedback: false,
           child: result,
           borderRadius: widget.buttonDecoration?.borderRadius


### PR DESCRIPTION
I created this because on Flutter Web, when you move your mouse over the button it shows a grey box around the Inkwell by default. It's annoying, so now we can remove it or change it