### PR TITLE
#145 Bug Fixed

### DIFF
--- a/lib/src/dropdown_button2.dart
+++ b/lib/src/dropdown_button2.dart
@@ -1500,7 +1500,7 @@ class DropdownButton2State<T> extends State<DropdownButton2<T>>
     if (result == null) {
       // If there's no MediaQuery, then use the window aspect to determine
       // orientation.
-      final Size size = View.of(context).physicalSize;
+      final Size size = MediaQuery.of(context).size;
       result = size.width > size.height
           ? Orientation.landscape
           : Orientation.portrait;


### PR DESCRIPTION
ERROR
Try correcting the name to the name of an existing getter, or defining a getter or field named 'View'. final Size size = View.of(context).physicalSize;

SOLUTION
In that case, you can replace View with MediaQuery and use the size property to get the physical size of the screen.