### PR TITLE
fix assertion failure when dropdownStyleData's decoration has non-nul…

### DIFF
--- a/lib/src/dropdown_button2.dart
+++ b/lib/src/dropdown_button2.dart
@@ -55,7 +55,7 @@ class _DropdownMenuPainter extends CustomPainter {
                   boxShadow: dropdownDecoration.boxShadow ??
                       kElevationToShadow[elevation],
                 )
-                .createBoxPainter() ??
+                .createBoxPainter((){}) ??
             BoxDecoration(
               // If you add an image here, you must provide a real
               // configuration in the paint() function and you must provide some sort


### PR DESCRIPTION
`createBoxPainter` of `BoxDecoration` has a assertion ` assert(onChanged != null || image == null)`, so when there's a non-null image in  `DropdownStyleData`, `onChanged` callback is required. 