### PR TITLE
Move some packages `dependencies` to `dev_dependencies`.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,13 +12,13 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  file: ^7.0.0
-  platform: ^3.1.0
 
 dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
+  file: ^7.0.0
+  platform: ^3.1.0
 
 flutter:
   fonts:


### PR DESCRIPTION
Have some packages like `dependencies` specified in `pudspec.yaml`, but theses are used in tests only, for this reason, should move it to `dev_dependencies`.