### PR TITLE
Add `backgroundColor` to customize dropdown style

### DIFF
--- a/lib/src/dropdown_button2.dart
+++ b/lib/src/dropdown_button2.dart
@@ -390,7 +390,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
       opacity: _fadeOpacity,
       child: CustomPaint(
         painter: _DropdownMenuPainter(
-          color: Theme.of(context).canvasColor,
+          color: dropdownStyle.backgroundColor ?? Theme.of(context).canvasColor,
           elevation: dropdownStyle.elevation,
           selectedIndex: route.selectedIndex,
           resize: _resize,

--- a/lib/src/dropdown_button2_data.dart
+++ b/lib/src/dropdown_button2_data.dart
@@ -113,6 +113,7 @@ class DropdownStyleData {
     this.useRootNavigator = false,
     this.scrollbarTheme,
     this.openInterval = const Interval(0.25, 0.5),
+    this.backgroundColor,
   });
 
   /// The maximum height of the dropdown menu
@@ -178,6 +179,11 @@ class DropdownStyleData {
 
   /// The animation curve used for opening the dropdown menu (forward direction)
   final Interval openInterval;
+
+  /// The background color of the dropdown.
+  ///
+  /// If it is not provided, the theme's ThemeData.canvasColor will be used instead.
+  final Color? backgroundColor;
 }
 
 /// A class to configure the theme of the dropdown menu items.


### PR DESCRIPTION
It is good to have possibility to change the dropdown background color especially if standard `DropdownButton` allows this.