### PR TITLE
Use null-aware operators to get `thumbVisibility` and `thickness` from `ScrollbarThemeData` for iOS.

### DIFF
--- a/lib/src/dropdown_button2.dart
+++ b/lib/src/dropdown_button2.dart
@@ -333,7 +333,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
 
   ScrollbarThemeData? get _scrollbarTheme => dropdownStyle.scrollbarTheme;
 
-  bool? get _iOSThumbVisibility => _scrollbarTheme?.thumbVisibility!.resolve(_states);
+  bool? get _iOSThumbVisibility => _scrollbarTheme?.thumbVisibility?.resolve(_states);
 
   Widget get _materialScrollBar => Theme(
         data: Theme.of(context).copyWith(
@@ -357,7 +357,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
         ),
         child: Scrollbar(
           thumbVisibility: _iOSThumbVisibility ?? true,
-          thickness: _scrollbarTheme?.thickness!.resolve(_states),
+          thickness: _scrollbarTheme?.thickness?.resolve(_states),
           radius: _scrollbarTheme?.radius,
           child: ListView(
             // Ensure this always inherits the PrimaryScrollController


### PR DESCRIPTION
This prevents crashes when `thumbVisibility` or `thickness` are null on iOS.