### PR TITLE
Add support for searchNotFoundWidget in DropdownSearchData

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,10 @@ Widget build(BuildContext context) {
                 ),
               ),
             ),
+            searchNotFoundWidget: const Padding(
+              padding: EdgeInsets.all(8),
+              child: Text('No Items Found!'),
+            ),
             searchMatchFn: (item, searchValue) {
               return item.value.toString().contains(searchValue);
             },

--- a/packages/dropdown_button2/lib/src/dropdown_menu.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_menu.dart
@@ -174,55 +174,58 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
                 children: <Widget>[
                   if (searchData?.searchInnerWidget != null)
                     searchData!.searchInnerWidget!,
-                  Flexible(
-                    child: Padding(
-                      padding: dropdownStyle.scrollPadding ?? EdgeInsets.zero,
-                      child: ScrollConfiguration(
-                        // Dropdown menus should never overscroll or display an overscroll indicator.
-                        // Scrollbars are built-in below.
-                        // Platform must use Theme and ScrollPhysics must be Clamping.
-                        behavior: ScrollConfiguration.of(context).copyWith(
-                          scrollbars: false,
-                          overscroll: false,
-                          physics: const ClampingScrollPhysics(),
-                          platform: Theme.of(context).platform,
-                        ),
-                        child: PrimaryScrollController(
-                          controller: route.scrollController!,
-                          child: Theme(
-                            data: Theme.of(context).copyWith(
-                              scrollbarTheme: dropdownStyle.scrollbarTheme,
-                            ),
-                            child: Scrollbar(
-                              thumbVisibility:
-                                  // ignore: avoid_bool_literals_in_conditional_expressions
-                                  _isIOS ? _iOSThumbVisibility : true,
-                              thickness: _isIOS
-                                  ? _scrollbarTheme?.thickness?.resolve(_states)
-                                  : null,
-                              radius: _isIOS ? _scrollbarTheme?.radius : null,
-                              child: ListView.separated(
-                                // Ensure this always inherits the PrimaryScrollController
-                                primary: true,
-                                shrinkWrap: true,
-                                padding: dropdownStyle.padding ??
-                                    kMaterialListPadding,
-                                itemCount: _children.length,
-                                itemBuilder: (context, index) =>
-                                    _children[index],
-                                separatorBuilder: (context, index) =>
-                                    separator != null
-                                        ? SizedBox(
-                                            height: separator!.height,
-                                            child: separator)
-                                        : const SizedBox.shrink(),
+                  if(_children.isEmpty && searchData?.searchNotFoundWidget != null)
+                    searchData!.searchNotFoundWidget!
+                  else
+                    Flexible(
+                      child: Padding(
+                        padding: dropdownStyle.scrollPadding ?? EdgeInsets.zero,
+                        child: ScrollConfiguration(
+                          // Dropdown menus should never overscroll or display an overscroll indicator.
+                          // Scrollbars are built-in below.
+                          // Platform must use Theme and ScrollPhysics must be Clamping.
+                          behavior: ScrollConfiguration.of(context).copyWith(
+                            scrollbars: false,
+                            overscroll: false,
+                            physics: const ClampingScrollPhysics(),
+                            platform: Theme.of(context).platform,
+                          ),
+                          child: PrimaryScrollController(
+                            controller: route.scrollController!,
+                            child: Theme(
+                              data: Theme.of(context).copyWith(
+                                scrollbarTheme: dropdownStyle.scrollbarTheme,
+                              ),
+                              child: Scrollbar(
+                                thumbVisibility:
+                                    // ignore: avoid_bool_literals_in_conditional_expressions
+                                    _isIOS ? _iOSThumbVisibility : true,
+                                thickness: _isIOS
+                                    ? _scrollbarTheme?.thickness?.resolve(_states)
+                                    : null,
+                                radius: _isIOS ? _scrollbarTheme?.radius : null,
+                                child: ListView.separated(
+                                  // Ensure this always inherits the PrimaryScrollController
+                                  primary: true,
+                                  shrinkWrap: true,
+                                  padding: dropdownStyle.padding ??
+                                      kMaterialListPadding,
+                                  itemCount: _children.length,
+                                  itemBuilder: (context, index) =>
+                                      _children[index],
+                                  separatorBuilder: (context, index) =>
+                                      separator != null
+                                          ? SizedBox(
+                                              height: separator!.height,
+                                              child: separator)
+                                          : const SizedBox.shrink(),
+                                ),
                               ),
                             ),
                           ),
                         ),
                       ),
                     ),
-                  ),
                 ],
               ),
             ),

--- a/packages/dropdown_button2/lib/src/dropdown_style_data.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_style_data.dart
@@ -245,6 +245,7 @@ class DropdownSearchData<T> {
   const DropdownSearchData({
     this.searchController,
     this.searchInnerWidget,
+    this.searchNotFoundWidget,
     this.searchInnerWidgetHeight,
     this.searchMatchFn,
   }) : assert(
@@ -260,6 +261,9 @@ class DropdownSearchData<T> {
   /// The widget to use for searchable dropdowns, such as search bar.
   /// It will be shown at the top of the dropdown menu.
   final Widget? searchInnerWidget;
+
+  /// The widget to display when no suggestions are available.
+  final Widget? searchNotFoundWidget;
 
   /// The height of the searchInnerWidget if used.
   final double? searchInnerWidgetHeight;

--- a/packages/dropdown_button2_test/lib/src/search_example.dart
+++ b/packages/dropdown_button2_test/lib/src/search_example.dart
@@ -98,6 +98,10 @@ class _SearchExampleState extends State<SearchExample> {
                   ),
                 ),
               ),
+              searchNotFoundWidget: const Padding(
+                padding: EdgeInsets.all(8),
+                child: Text('No Items Found!'),
+              ),
               searchMatchFn: (item, searchValue) {
                 return item.value.toString().contains(searchValue);
               },


### PR DESCRIPTION
The widget to display when no suggestions are available.

```dart
DropdownSearchData(
  // ....
  searchNotFoundWidget: const Padding(
    padding: EdgeInsets.all(8),
    child: Text('No Items Found!'),
  )
)
```
![](https://github.com/AhmedLSayed9/dropdown_button2/assets/12654289/c6d5f724-6e1e-4ef5-b156-01b02df5f5e6)
