### PR TITLE
Bugfix for issue #285: Scroll Position not as expected when opening the dropdown menu without prior resetting the search querry

### DIFF
--- a/packages/dropdown_button2/lib/src/dropdown_route.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_route.dart
@@ -126,7 +126,12 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
             itemHeights.length,
       );
       if (searchData?.searchController?.text case final searchText?) {
-        offset += _getSearchItemsHeight(index, searchText);
+        final searchMatchFn =
+            searchData?.searchMatchFn ?? _defaultSearchMatchFn();
+        final selectedItemExist = searchMatchFn(items[index], searchText);
+        if (selectedItemExist) {
+          offset += _getSearchItemsHeight(index, searchText);
+        }
       } else {
         for (int i = 0; i < index; i++) {
           offset += itemHeights[i];

--- a/packages/dropdown_button2/lib/src/dropdown_route.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_route.dart
@@ -125,33 +125,27 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
         items.length + (dropdownSeparator != null ? items.length - 1 : 0) ==
             itemHeights.length,
       );
-      final double? searchOffset = _getSearchItemsHeight(endIndex: index);
-      if (searchOffset != null) {
-        offset += searchOffset;
+      if (searchData?.searchController?.text case final searchText?) {
+        offset += _getSearchItemsHeight(index, searchText);
       } else {
-        offset += itemHeights
-            .sublist(0, index)
-            .reduce((double total, double height) => total + height);
+        for (int i = 0; i < index; i++) {
+          offset += itemHeights[i];
+        }
       }
     }
 
     return offset;
   }
 
-  double? _getSearchItemsHeight({int? endIndex}) {
-    final String? currentSearch = searchData?.searchController?.text;
-    if (currentSearch == null || currentSearch.isEmpty) {
-      return null;
-    }
-    double height = 0.0;
-    final int limit = endIndex ?? items.length;
+  double _getSearchItemsHeight(int index, String searchText) {
+    var itemsHeight = 0.0;
     final searchMatchFn = searchData?.searchMatchFn ?? _defaultSearchMatchFn();
-    for (int index = 0; index < limit; ++index) {
-      if (searchMatchFn(items[index], currentSearch)) {
-        height += itemHeights[index];
+    for (int i = 0; i < index; i++) {
+      if (searchMatchFn(items[i], searchText)) {
+        itemsHeight += itemHeights[i];
       }
     }
-    return height;
+    return itemsHeight;
   }
 
   // Returns the vertical extent of the menu and the initial scrollOffset
@@ -175,13 +169,10 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     final double innerWidgetHeight = searchData?.searchBarWidgetHeight ?? 0.0;
     actualMenuHeight += innerWidgetHeight;
     if (items.isNotEmpty) {
-      final double? searchHeight = _getSearchItemsHeight();
-      if (searchHeight != null) {
-        actualMenuHeight += searchHeight;
-      } else {
-        actualMenuHeight +=
-            itemHeights.reduce((double total, double height) => total + height);
-      }
+      final searchText = searchData?.searchController?.text;
+      actualMenuHeight += searchText != null
+          ? _getSearchItemsHeight(items.length, searchText)
+          : itemHeights.reduce((double total, double height) => total + height);
     }
 
     // Use actualMenuHeight if it's less than maxHeight.

--- a/packages/dropdown_button2/lib/src/dropdown_route.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_route.dart
@@ -125,12 +125,33 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
         items.length + (dropdownSeparator != null ? items.length - 1 : 0) ==
             itemHeights.length,
       );
-      offset += itemHeights
-          .sublist(0, index)
-          .reduce((double total, double height) => total + height);
+      final double? searchOffset = _getSearchItemsHeight(endIndex: index);
+      if (searchOffset != null) {
+        offset += searchOffset;
+      } else {
+        offset += itemHeights
+            .sublist(0, index)
+            .reduce((double total, double height) => total + height);
+      }
     }
 
     return offset;
+  }
+
+  double? _getSearchItemsHeight({int? endIndex}) {
+    final String? currentSearch = searchData?.searchController?.text;
+    if (currentSearch == null || currentSearch.isEmpty) {
+      return null;
+    }
+    double height = 0.0;
+    final int limit = endIndex ?? items.length;
+    final searchMatchFn = searchData?.searchMatchFn ?? _defaultSearchMatchFn();
+    for (int index = 0; index < limit; ++index) {
+      if (searchMatchFn(items[index], currentSearch)) {
+        height += itemHeights[index];
+      }
+    }
+    return height;
   }
 
   // Returns the vertical extent of the menu and the initial scrollOffset
@@ -154,8 +175,13 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     final double innerWidgetHeight = searchData?.searchBarWidgetHeight ?? 0.0;
     actualMenuHeight += innerWidgetHeight;
     if (items.isNotEmpty) {
-      actualMenuHeight +=
-          itemHeights.reduce((double total, double height) => total + height);
+      final double? searchHeight = _getSearchItemsHeight();
+      if (searchHeight != null) {
+        actualMenuHeight += searchHeight;
+      } else {
+        actualMenuHeight +=
+            itemHeights.reduce((double total, double height) => total + height);
+      }
     }
 
     // Use actualMenuHeight if it's less than maxHeight.


### PR DESCRIPTION
Solves #285. As discussed in #280.
Old behaviour:
![search_index](https://github.com/AhmedLSayed9/dropdown_button2/assets/74505744/a1a998d2-935d-438e-9424-852bf6241e8f)

New behaviour:
![search_index_solved](https://github.com/AhmedLSayed9/dropdown_button2/assets/74505744/19ecf454-0b4b-44fb-90a7-9148f6bb58a3)


