### PR TITLE
Bugfix: Ink splashes got displayed over search widget

### DIFF
--- a/packages/dropdown_button2/CHANGELOG.md
+++ b/packages/dropdown_button2/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 - Enhance scroll position when using searchable dropdown, closes #285.
+- Temporarily fix ink splash gets displayed over search widget, closes #290.
 
 ## 3.0.0-beta.16
 

--- a/packages/dropdown_button2/lib/src/dropdown_menu.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_menu.dart
@@ -158,72 +158,74 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
             searchData!.noResultsWidget!
           else
             Flexible(
-              child: Padding(
-                padding: dropdownStyle.scrollPadding ?? EdgeInsets.zero,
-                child: ScrollConfiguration(
-                  // Dropdown menus should never overscroll or display an overscroll indicator.
-                  // Scrollbars are built-in below.
-                  // Platform must use Theme and ScrollPhysics must be Clamping.
-                  behavior: ScrollConfiguration.of(context).copyWith(
-                    scrollbars: false,
-                    overscroll: false,
-                    physics: const ClampingScrollPhysics(),
-                    platform: Theme.of(context).platform,
-                  ),
-                  child: PrimaryScrollController(
-                    controller: route.scrollController!,
-                    child: Theme(
-                      data: Theme.of(context).copyWith(
-                        scrollbarTheme: dropdownStyle.scrollbarTheme,
-                      ),
-                      child: Scrollbar(
-                        thumbVisibility:
-                            // ignore: avoid_bool_literals_in_conditional_expressions
-                            _isIOS ? _iOSThumbVisibility : true,
-                        thickness: _isIOS
-                            ? _scrollbarTheme?.thickness?.resolve(_states)
-                            : null,
-                        radius: _isIOS ? _scrollbarTheme?.radius : null,
-                        child: ListView.custom(
-                          // Ensure this always inherits the PrimaryScrollController
-                          primary: true,
-                          shrinkWrap: true,
-                          padding:
-                              dropdownStyle.padding ?? kMaterialListPadding,
-                          itemExtentBuilder: _hasIntrinsicHeight
-                              ? null
-                              : (index, dimensions) {
-                                  final childrenLength = separator == null
-                                      ? _children.length
-                                      : SeparatedSliverChildBuilderDelegate
-                                          .computeActualChildCount(
-                                              _children.length);
-                                  // TODO(Ahmed): Remove this when https://github.com/flutter/flutter/pull/142428
-                                  // is supported by the min version of the package [Flutter>=3.22.0].
-                                  if (index >= childrenLength) {
-                                    return 100;
-                                  }
-                                  return separator != null && index.isOdd
-                                      ? separator.height
-                                      : route.itemHeights[index];
-                                },
-                          childrenDelegate: separator == null
-                              ? SliverChildBuilderDelegate(
-                                  (context, index) => _children[index],
-                                  childCount: _children.length,
-                                )
-                              : SeparatedSliverChildBuilderDelegate(
-                                  itemCount: _children.length,
-                                  itemBuilder: (context, index) =>
-                                      _children[index],
-                                  separatorBuilder: (context, index) =>
-                                      SizedBox(
-                                    height: separator.intrinsicHeight
-                                        ? null
-                                        : separator.height,
-                                    child: separator,
+              child: Material(
+                child: Padding(
+                  padding: dropdownStyle.scrollPadding ?? EdgeInsets.zero,
+                  child: ScrollConfiguration(
+                    // Dropdown menus should never overscroll or display an overscroll indicator.
+                    // Scrollbars are built-in below.
+                    // Platform must use Theme and ScrollPhysics must be Clamping.
+                    behavior: ScrollConfiguration.of(context).copyWith(
+                      scrollbars: false,
+                      overscroll: false,
+                      physics: const ClampingScrollPhysics(),
+                      platform: Theme.of(context).platform,
+                    ),
+                    child: PrimaryScrollController(
+                      controller: route.scrollController!,
+                      child: Theme(
+                        data: Theme.of(context).copyWith(
+                          scrollbarTheme: dropdownStyle.scrollbarTheme,
+                        ),
+                        child: Scrollbar(
+                          thumbVisibility:
+                              // ignore: avoid_bool_literals_in_conditional_expressions
+                              _isIOS ? _iOSThumbVisibility : true,
+                          thickness: _isIOS
+                              ? _scrollbarTheme?.thickness?.resolve(_states)
+                              : null,
+                          radius: _isIOS ? _scrollbarTheme?.radius : null,
+                          child: ListView.custom(
+                            // Ensure this always inherits the PrimaryScrollController
+                            primary: true,
+                            shrinkWrap: true,
+                            padding:
+                                dropdownStyle.padding ?? kMaterialListPadding,
+                            itemExtentBuilder: _hasIntrinsicHeight
+                                ? null
+                                : (index, dimensions) {
+                                    final childrenLength = separator == null
+                                        ? _children.length
+                                        : SeparatedSliverChildBuilderDelegate
+                                            .computeActualChildCount(
+                                                _children.length);
+                                    // TODO(Ahmed): Remove this when https://github.com/flutter/flutter/pull/142428
+                                    // is supported by the min version of the package [Flutter>=3.22.0].
+                                    if (index >= childrenLength) {
+                                      return 100;
+                                    }
+                                    return separator != null && index.isOdd
+                                        ? separator.height
+                                        : route.itemHeights[index];
+                                  },
+                            childrenDelegate: separator == null
+                                ? SliverChildBuilderDelegate(
+                                    (context, index) => _children[index],
+                                    childCount: _children.length,
+                                  )
+                                : SeparatedSliverChildBuilderDelegate(
+                                    itemCount: _children.length,
+                                    itemBuilder: (context, index) =>
+                                        _children[index],
+                                    separatorBuilder: (context, index) =>
+                                        SizedBox(
+                                      height: separator.intrinsicHeight
+                                          ? null
+                                          : separator.height,
+                                      child: separator,
+                                    ),
                                   ),
-                                ),
+                          ),
                         ),
                       ),
                     ),

--- a/packages/dropdown_button2/lib/src/dropdown_menu.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_menu.dart
@@ -158,6 +158,9 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
             searchData!.noResultsWidget!
           else
             Flexible(
+              // This Material wrapper is temporary until it's fixed by flutter at:
+              // https://github.com/flutter/flutter/issues/86584
+              // https://github.com/flutter/flutter/issues/73315
               child: Material(
                 type: MaterialType.transparency,
                 textStyle: route.style,

--- a/packages/dropdown_button2/lib/src/dropdown_menu.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_menu.dart
@@ -159,6 +159,8 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
           else
             Flexible(
               child: Material(
+                type: MaterialType.transparency,
+                textStyle: route.style,
                 child: Padding(
                   padding: dropdownStyle.scrollPadding ?? EdgeInsets.zero,
                   child: ScrollConfiguration(


### PR DESCRIPTION
Before:
![ink_splash](https://github.com/AhmedLSayed9/dropdown_button2/assets/74505744/a089262b-e150-455e-b0ef-4b7f4370c149)

After:
![ink_splash_solved](https://github.com/AhmedLSayed9/dropdown_button2/assets/74505744/ef663912-7350-4a4a-8541-0398b7368ef3)

Same code to reproduce as in issue #290