### PR TITLE
Remove an assert from updateSelectedIndex method

### DIFF
--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -511,10 +511,6 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>>
       return;
     }
 
-    assert(widget.items!
-            .where((DropdownItem<T> item) => item.value == _currentValue)
-            .length ==
-        1);
     for (int itemIndex = 0; itemIndex < widget.items!.length; itemIndex++) {
       if (widget.items![itemIndex].value == _currentValue) {
         _selectedIndex = itemIndex;
@@ -758,7 +754,7 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>>
             valueListenable: widget.valueListenable ??
                 widget.multiValueListenable ??
                 ValueNotifier(null),
-            builder: (context, multiValue, _) {
+            builder: (context, _, __) {
               _uniqueValueAssert(
                 widget.items,
                 widget.valueListenable,


### PR DESCRIPTION
We're removing the assert from `updateSelectedIndex` method as it'll throw if `valueListenable` changes but DropdownButton2 is no longer in the tree. We already use `_uniqueValueAssert` instead, which gets invoked properly inside ValueListenableBuilder.