### PR TITLE
Avoid dropdown internal FocusNode listener leak when replaced by an e…

### DIFF
--- a/packages/dropdown_button2/CHANGELOG.md
+++ b/packages/dropdown_button2/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Avoid dropdown internal FocusNode listener leak when replaced by an external FocusNode
+
 ## 3.0.0-beta.22
 
 - Fix errorStyle has no effect for DropdownButtonFormField2, closes #327.

--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -493,6 +493,10 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBin
     super.didUpdateWidget(oldWidget);
     if (widget.focusNode != oldWidget.focusNode) {
       oldWidget.focusNode?.removeListener(_handleFocusChanged);
+      if (_internalNode != null && widget.focusNode != null) {
+        _internalNode!.removeListener(_handleFocusChanged);
+      }
+
       if (widget.focusNode == null) {
         _internalNode ??= _createFocusNode();
       }


### PR DESCRIPTION
…xternal FocusNode