### PR TITLE
fix: add validation to disposed error

### DIFF
--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -684,6 +684,9 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBin
       _dropdownRoute?._childNode.requestFocus();
     });
     navigator.push(_dropdownRoute!).then<void>((_DropdownRouteResult<T>? newValue) {
+      if(!mounted) {
+        return;
+      }
       _removeDropdownRoute();
       _isMenuOpen.value = false;
       widget.onMenuStateChange?.call(false);


### PR DESCRIPTION
Closes #384 

When you resize the dropdown button sometimes we have a log like the print below. 

<img width="1293" alt="Screenshot 2025-06-18 at 15 37 33" src="https://github.com/user-attachments/assets/8b8a66bd-8933-49c1-940f-0362d3e6047e" />
