### PR TITLE
Add `barrierBlocksInteraction` to allow interaction with underlying widgets while the dropdown menu is open

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ customize to your needs.
 | [barrierColor](https://pub.dev/documentation/dropdown_button2/latest/dropdown_button2/DropdownButton2/barrierColor.html)                     | The color to use for the modal barrier. If this is null, the barrier will be transparent | Color                      |    No    |
 | [barrierLabel](https://pub.dev/documentation/dropdown_button2/latest/dropdown_button2/DropdownButton2/barrierLabel.html)                     | The semantic label used for a dismissible barrier                                        | String                     |    No    |
 | [barrierCoversButton](https://pub.dev/documentation/dropdown_button2/latest/dropdown_button2/DropdownButton2/barrierCoversButton.html)       | Specifies whether the modal barrier should cover the dropdown button or not.             | bool                       |    No    |
+| [barrierBlocksInteraction](https://pub.dev/documentation/dropdown_button2/latest/dropdown_button2/DropdownButton2/barrierBlocksInteraction.html) | Whether to block interaction with underlying widgets when the dropdown menu is open      | bool                       |    No    |
 | [openDropdownListenable](https://pub.dev/documentation/dropdown_button2/latest/dropdown_button2/DropdownButton2/openDropdownListenable.html) | A [Listenable] that can be used to programmatically open the dropdown menu.              | Listenable?                |    No    |
 
 #### Subclass ButtonStyleData:

--- a/packages/dropdown_button2/CHANGELOG.md
+++ b/packages/dropdown_button2/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add ARIA menu roles to menu-related widgets for accessibility [Flutter core].
 - Add `anchoredMinHeight` to keep the menu anchored to the button and shrink to fit when possible, closes #429.
 - Re-lay out dropdown menu on ancestor scroll.
+- Add `barrierBlocksInteraction` to allow interaction with underlying widgets while the dropdown menu is open.
 
 ## 3.0.0
 

--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -358,10 +358,10 @@ class DropdownButton2<T> extends StatefulWidget {
   /// Defaults to `true`.
   final bool barrierCoversButton;
 
-  /// Whether to block interaction with underlying widgets when the dropdown is open.
+  /// Whether to block interaction with underlying widgets when the dropdown menu is open.
   ///
-  /// When false, taps outside the dropdown can pass through to underlying
-  /// widgets while still dismissing the dropdown.
+  /// When false, taps outside the dropdown menu can pass through to underlying
+  /// widgets while still dismissing the menu.
   ///
   /// Defaults to true.
   final bool barrierBlocksInteraction;

--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -363,7 +363,7 @@ class DropdownButton2<T> extends StatefulWidget {
   /// When false, taps outside the dropdown menu can pass through to underlying
   /// widgets while still dismissing the menu.
   ///
-  /// Defaults to true.
+  /// Defaults to `true`.
   final bool barrierBlocksInteraction;
 
   /// The color to use for the modal barrier. If this is null, the barrier will

--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -7,18 +7,20 @@
 
 import 'dart:math' as math;
 import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'seperated_sliver_child_builder_delegate.dart';
 
 part 'button_style_data.dart';
-part 'dropdown_style_data.dart';
-part 'dropdown_route.dart';
 part 'dropdown_menu.dart';
 part 'dropdown_menu_item.dart';
 part 'dropdown_menu_separators.dart';
+part 'dropdown_route.dart';
+part 'dropdown_style_data.dart';
 part 'enums.dart';
 part 'utils.dart';
 
@@ -123,6 +125,7 @@ class DropdownButton2<T> extends StatefulWidget {
     this.openWithLongPress = false,
     this.barrierDismissible = true,
     this.barrierCoversButton = true,
+    this.barrierBlocksInteraction = true,
     this.barrierColor,
     this.barrierLabel,
     this.openDropdownListenable,
@@ -163,6 +166,7 @@ class DropdownButton2<T> extends StatefulWidget {
     required this.openWithLongPress,
     required this.barrierDismissible,
     required this.barrierCoversButton,
+    required this.barrierBlocksInteraction,
     required this.barrierColor,
     required this.barrierLabel,
     required this.openDropdownListenable,
@@ -353,6 +357,14 @@ class DropdownButton2<T> extends StatefulWidget {
   ///
   /// Defaults to `true`.
   final bool barrierCoversButton;
+
+  /// Whether to block interaction with underlying widgets when the dropdown is open.
+  ///
+  /// When false, taps outside the dropdown can pass through to underlying
+  /// widgets while still dismissing the dropdown.
+  ///
+  /// Defaults to true.
+  final bool barrierBlocksInteraction;
 
   /// The color to use for the modal barrier. If this is null, the barrier will
   /// be transparent.
@@ -726,6 +738,7 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBin
       barrierLabel:
           widget.barrierLabel ?? MaterialLocalizations.of(context).modalBarrierDismissLabel,
       barrierCoversButton: widget.barrierCoversButton,
+      barrierBlocksInteraction: widget.barrierBlocksInteraction,
       parentFocusNode: _focusNode,
       enableFeedback: widget.enableFeedback ?? true,
       textDirection: textDirection,
@@ -1118,6 +1131,7 @@ class DropdownButtonFormField2<T> extends FormField<T> {
     bool openWithLongPress = false,
     bool barrierDismissible = true,
     bool barrierCoversButton = true,
+    bool barrierBlocksInteraction = true,
     Color? barrierColor,
     String? barrierLabel,
     Listenable? openDropdownListenable,
@@ -1209,6 +1223,7 @@ class DropdownButtonFormField2<T> extends FormField<T> {
                  openWithLongPress: openWithLongPress,
                  barrierDismissible: barrierDismissible,
                  barrierCoversButton: barrierCoversButton,
+                 barrierBlocksInteraction: barrierBlocksInteraction,
                  barrierColor: barrierColor,
                  barrierLabel: barrierLabel,
                  openDropdownListenable: openDropdownListenable,

--- a/packages/dropdown_button2/lib/src/dropdown_route.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_route.dart
@@ -64,17 +64,33 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
 
   final FocusScopeNode _childNode = FocusScopeNode(debugLabel: 'Child');
 
+  /// When [barrierBlocksInteraction] is false, wraps the default modal barrier
+  /// so pointer events pass through while still dismissing on barrier tap (if dismissible).
   @override
-  Widget buildModalBarrier() => IgnorePointer(
-    ignoring: !barrierBlocksInteraction,
-    child: super.buildModalBarrier(),
-  );
+  Widget buildModalBarrier() {
+    if (barrierBlocksInteraction) {
+      return super.buildModalBarrier();
+    }
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (PointerDownEvent event) {
+        if (buttonRect.value!.contains(event.position)) {
+          // Intercept anchor-button taps while the menu is open so the underlying
+          // button's GestureDetector doesn't fire onTap.
+          GestureBinding.instance.cancelPointer(event.pointer);
+        }
+        if (barrierDismissible) {
+          _dismiss();
+        }
+      },
+      child: IgnorePointer(child: super.buildModalBarrier()),
+    );
+  }
 
   @override
   Widget buildPage(BuildContext context, _, __) {
-    final TextDirection resolvedTextDirection = textDirection ?? Directionality.of(context);
     return Directionality(
-      textDirection: resolvedTextDirection,
+      textDirection: textDirection ?? Directionality.of(context),
       child: FocusScope.withExternalFocusNode(
         focusScopeNode: _childNode,
         parentNode: parentFocusNode,
@@ -104,56 +120,15 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
                   style: style,
                   enableFeedback: enableFeedback,
                 );
-                final dismissibleRoutePage = barrierBlocksInteraction
-                    ? routePage
-                    : Stack(
-                        fit: StackFit.expand,
-                        children: [
-                          // In non-blocking mode, listen for outside taps so we can
-                          // dismiss the menu, while still passing the same pointer
-                          // event through to underlying widgets.
-                          if (barrierDismissible)
-                            Positioned.fill(
-                              child: Listener(
-                                behavior: HitTestBehavior.translucent,
-                                onPointerDown: (PointerDownEvent event) {
-                                  final Rect menuRect = getMenuRect(
-                                    buttonRect: rect,
-                                    availableSize: Size(
-                                      constraints.maxWidth,
-                                      actualConstraints.maxHeight,
-                                    ),
-                                    mediaQueryPadding: mediaQueryPadding,
-                                    textDirection: resolvedTextDirection,
-                                  );
-                                  if (!menuRect.contains(event.position)) {
-                                    _dismiss();
-                                  }
-                                },
-                              ),
-                            ),
-                          routePage,
-                          // Always intercept anchor-button taps while the menu is open
-                          // so the underlying button does not receive the same gesture.
-                          // If the route is dismissible, treat the tap as close.
-                          Positioned.fromRect(
-                            rect: rect,
-                            child: GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTap: barrierDismissible ? _dismiss : () {},
-                            ),
-                          ),
-                        ],
-                      );
                 return barrierCoversButton
-                    ? dismissibleRoutePage
+                    ? routePage
                     : _CustomModalBarrier(
                         barrierColor: _altBarrierColor,
                         animation: animation,
                         barrierCurve: barrierCurve,
                         buttonRect: rect,
                         buttonBorderRadius: buttonBorderRadius ?? BorderRadius.zero,
-                        child: dismissibleRoutePage,
+                        child: routePage,
                       );
               },
             );
@@ -346,81 +321,6 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     return _MenuLimits(menuTop, menuBottom, menuHeight, scrollOffset);
   }
 
-  double getMenuWidth({
-    required double availableWidth,
-    required double buttonWidth,
-  }) {
-    // The width of a menu should be at most the view width. This ensures that
-    // the menu does not extend past the left and right edges of the screen.
-    final double? configuredMenuWidth = dropdownStyle.width;
-    return math.min(availableWidth, configuredMenuWidth ?? buttonWidth);
-  }
-
-  double getMenuLeft({
-    required Rect buttonRect,
-    required double availableWidth,
-    required double menuWidth,
-    required TextDirection textDirection,
-  }) {
-    final Offset offset = dropdownStyle.offset;
-    return switch (dropdownStyle.direction) {
-      DropdownDirection.textDirection => switch (textDirection) {
-        TextDirection.rtl => clampDouble(
-          buttonRect.right - menuWidth + offset.dx,
-          0.0,
-          availableWidth - menuWidth,
-        ),
-        TextDirection.ltr => clampDouble(
-          buttonRect.left + offset.dx,
-          0.0,
-          availableWidth - menuWidth,
-        ),
-      },
-      DropdownDirection.right => clampDouble(
-        buttonRect.left + offset.dx,
-        0.0,
-        availableWidth - menuWidth,
-      ),
-      DropdownDirection.left => clampDouble(
-        buttonRect.right - menuWidth + offset.dx,
-        0.0,
-        availableWidth - menuWidth,
-      ),
-      DropdownDirection.center => clampDouble(
-        (availableWidth - menuWidth) / 2 + offset.dx,
-        0.0,
-        availableWidth - menuWidth,
-      ),
-    };
-  }
-
-  Rect getMenuRect({
-    required Rect buttonRect,
-    required Size availableSize,
-    required EdgeInsets mediaQueryPadding,
-    required TextDirection textDirection,
-  }) {
-    final _MenuLimits menuLimits = getMenuLimits(
-      buttonRect,
-      availableSize.height,
-      mediaQueryPadding,
-      selectedIndex,
-    );
-
-    final double menuWidth = getMenuWidth(
-      availableWidth: availableSize.width,
-      buttonWidth: buttonRect.width,
-    );
-    final double left = getMenuLeft(
-      buttonRect: buttonRect,
-      availableWidth: availableSize.width,
-      menuWidth: menuWidth,
-      textDirection: textDirection,
-    );
-
-    return Rect.fromLTWH(left, menuLimits.top, menuWidth, menuLimits.height);
-  }
-
   // The maximum height of a simple menu should be one or more rows less than
   // the view height. This ensures a tappable area outside of the simple menu
   // with which to dismiss the menu.
@@ -553,10 +453,10 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
       menuAnchoredTop: menuAnchoredTop,
       mediaQueryPadding: mediaQueryPadding,
     );
-    final double width = route.getMenuWidth(
-      availableWidth: constraints.maxWidth,
-      buttonWidth: buttonRect.width,
-    );
+    // The width of a menu should be at most the view width. This ensures that
+    // the menu does not extend past the left and right edges of the screen.
+    final double? menuWidth = route.dropdownStyle.width;
+    final double width = math.min(constraints.maxWidth, menuWidth ?? buttonRect.width);
     return BoxConstraints(
       minWidth: width,
       maxWidth: width,
@@ -586,12 +486,36 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     }());
     assert(textDirection != null);
 
-    final double left = route.getMenuLeft(
-      buttonRect: buttonRect,
-      availableWidth: size.width,
-      menuWidth: childSize.width,
-      textDirection: textDirection!,
-    );
+    final Offset offset = route.dropdownStyle.offset;
+    final double left = switch (route.dropdownStyle.direction) {
+      DropdownDirection.textDirection => switch (textDirection!) {
+        TextDirection.rtl => clampDouble(
+          buttonRect.right - childSize.width + offset.dx,
+          0.0,
+          size.width - childSize.width,
+        ),
+        TextDirection.ltr => clampDouble(
+          buttonRect.left + offset.dx,
+          0.0,
+          size.width - childSize.width,
+        ),
+      },
+      DropdownDirection.right => clampDouble(
+        buttonRect.left + offset.dx,
+        0.0,
+        size.width - childSize.width,
+      ),
+      DropdownDirection.left => clampDouble(
+        buttonRect.right - childSize.width + offset.dx,
+        0.0,
+        size.width - childSize.width,
+      ),
+      DropdownDirection.center => clampDouble(
+        (size.width - childSize.width) / 2 + offset.dx,
+        0.0,
+        size.width - childSize.width,
+      ),
+    };
 
     return Offset(left, menuLimits.top);
   }

--- a/packages/dropdown_button2/lib/src/dropdown_route.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_route.dart
@@ -14,6 +14,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     Color? barrierColor,
     this.barrierLabel,
     required this.barrierCoversButton,
+    required this.barrierBlocksInteraction,
     required this.parentFocusNode,
     required this.enableFeedback,
     required this.textDirection,
@@ -59,12 +60,21 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
 
   final bool barrierCoversButton;
 
+  final bool barrierBlocksInteraction;
+
   final FocusScopeNode _childNode = FocusScopeNode(debugLabel: 'Child');
 
   @override
+  Widget buildModalBarrier() => IgnorePointer(
+    ignoring: !barrierBlocksInteraction,
+    child: super.buildModalBarrier(),
+  );
+
+  @override
   Widget buildPage(BuildContext context, _, __) {
+    final TextDirection resolvedTextDirection = textDirection ?? Directionality.of(context);
     return Directionality(
-      textDirection: textDirection ?? Directionality.of(context),
+      textDirection: resolvedTextDirection,
       child: FocusScope.withExternalFocusNode(
         focusScopeNode: _childNode,
         parentNode: parentFocusNode,
@@ -94,15 +104,56 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
                   style: style,
                   enableFeedback: enableFeedback,
                 );
-                return barrierCoversButton
+                final dismissibleRoutePage = barrierBlocksInteraction
                     ? routePage
+                    : Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          // In non-blocking mode, listen for outside taps so we can
+                          // dismiss the menu, while still passing the same pointer
+                          // event through to underlying widgets.
+                          if (barrierDismissible)
+                            Positioned.fill(
+                              child: Listener(
+                                behavior: HitTestBehavior.translucent,
+                                onPointerDown: (PointerDownEvent event) {
+                                  final Rect menuRect = getMenuRect(
+                                    buttonRect: rect,
+                                    availableSize: Size(
+                                      constraints.maxWidth,
+                                      actualConstraints.maxHeight,
+                                    ),
+                                    mediaQueryPadding: mediaQueryPadding,
+                                    textDirection: resolvedTextDirection,
+                                  );
+                                  if (!menuRect.contains(event.position)) {
+                                    _dismiss();
+                                  }
+                                },
+                              ),
+                            ),
+                          routePage,
+                          // Always intercept anchor-button taps while the menu is open
+                          // so the underlying button does not receive the same gesture.
+                          // If the route is dismissible, treat the tap as close.
+                          Positioned.fromRect(
+                            rect: rect,
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: barrierDismissible ? _dismiss : () {},
+                            ),
+                          ),
+                        ],
+                      );
+                return barrierCoversButton
+                    ? dismissibleRoutePage
                     : _CustomModalBarrier(
                         barrierColor: _altBarrierColor,
                         animation: animation,
                         barrierCurve: barrierCurve,
                         buttonRect: rect,
                         buttonBorderRadius: buttonBorderRadius ?? BorderRadius.zero,
-                        child: routePage,
+                        child: dismissibleRoutePage,
                       );
               },
             );
@@ -295,6 +346,81 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     return _MenuLimits(menuTop, menuBottom, menuHeight, scrollOffset);
   }
 
+  double getMenuWidth({
+    required double availableWidth,
+    required double buttonWidth,
+  }) {
+    // The width of a menu should be at most the view width. This ensures that
+    // the menu does not extend past the left and right edges of the screen.
+    final double? configuredMenuWidth = dropdownStyle.width;
+    return math.min(availableWidth, configuredMenuWidth ?? buttonWidth);
+  }
+
+  double getMenuLeft({
+    required Rect buttonRect,
+    required double availableWidth,
+    required double menuWidth,
+    required TextDirection textDirection,
+  }) {
+    final Offset offset = dropdownStyle.offset;
+    return switch (dropdownStyle.direction) {
+      DropdownDirection.textDirection => switch (textDirection) {
+        TextDirection.rtl => clampDouble(
+          buttonRect.right - menuWidth + offset.dx,
+          0.0,
+          availableWidth - menuWidth,
+        ),
+        TextDirection.ltr => clampDouble(
+          buttonRect.left + offset.dx,
+          0.0,
+          availableWidth - menuWidth,
+        ),
+      },
+      DropdownDirection.right => clampDouble(
+        buttonRect.left + offset.dx,
+        0.0,
+        availableWidth - menuWidth,
+      ),
+      DropdownDirection.left => clampDouble(
+        buttonRect.right - menuWidth + offset.dx,
+        0.0,
+        availableWidth - menuWidth,
+      ),
+      DropdownDirection.center => clampDouble(
+        (availableWidth - menuWidth) / 2 + offset.dx,
+        0.0,
+        availableWidth - menuWidth,
+      ),
+    };
+  }
+
+  Rect getMenuRect({
+    required Rect buttonRect,
+    required Size availableSize,
+    required EdgeInsets mediaQueryPadding,
+    required TextDirection textDirection,
+  }) {
+    final _MenuLimits menuLimits = getMenuLimits(
+      buttonRect,
+      availableSize.height,
+      mediaQueryPadding,
+      selectedIndex,
+    );
+
+    final double menuWidth = getMenuWidth(
+      availableWidth: availableSize.width,
+      buttonWidth: buttonRect.width,
+    );
+    final double left = getMenuLeft(
+      buttonRect: buttonRect,
+      availableWidth: availableSize.width,
+      menuWidth: menuWidth,
+      textDirection: textDirection,
+    );
+
+    return Rect.fromLTWH(left, menuLimits.top, menuWidth, menuLimits.height);
+  }
+
   // The maximum height of a simple menu should be one or more rows less than
   // the view height. This ensures a tappable area outside of the simple menu
   // with which to dismiss the menu.
@@ -427,10 +553,10 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
       menuAnchoredTop: menuAnchoredTop,
       mediaQueryPadding: mediaQueryPadding,
     );
-    // The width of a menu should be at most the view width. This ensures that
-    // the menu does not extend past the left and right edges of the screen.
-    final double? menuWidth = route.dropdownStyle.width;
-    final double width = math.min(constraints.maxWidth, menuWidth ?? buttonRect.width);
+    final double width = route.getMenuWidth(
+      availableWidth: constraints.maxWidth,
+      buttonWidth: buttonRect.width,
+    );
     return BoxConstraints(
       minWidth: width,
       maxWidth: width,
@@ -460,36 +586,12 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     }());
     assert(textDirection != null);
 
-    final Offset offset = route.dropdownStyle.offset;
-    final double left = switch (route.dropdownStyle.direction) {
-      DropdownDirection.textDirection => switch (textDirection!) {
-        TextDirection.rtl => clampDouble(
-          buttonRect.right - childSize.width + offset.dx,
-          0.0,
-          size.width - childSize.width,
-        ),
-        TextDirection.ltr => clampDouble(
-          buttonRect.left + offset.dx,
-          0.0,
-          size.width - childSize.width,
-        ),
-      },
-      DropdownDirection.right => clampDouble(
-        buttonRect.left + offset.dx,
-        0.0,
-        size.width - childSize.width,
-      ),
-      DropdownDirection.left => clampDouble(
-        buttonRect.right - childSize.width + offset.dx,
-        0.0,
-        size.width - childSize.width,
-      ),
-      DropdownDirection.center => clampDouble(
-        (size.width - childSize.width) / 2 + offset.dx,
-        0.0,
-        size.width - childSize.width,
-      ),
-    };
+    final double left = route.getMenuLeft(
+      buttonRect: buttonRect,
+      availableWidth: size.width,
+      menuWidth: childSize.width,
+      textDirection: textDirection!,
+    );
 
     return Offset(left, menuLimits.top);
   }

--- a/packages/dropdown_button2/test/dropdown_button2_test.dart
+++ b/packages/dropdown_button2/test/dropdown_button2_test.dart
@@ -681,4 +681,92 @@ void main() {
       });
     },
   );
+
+  group('barrierBlocksInteraction', () {
+    final List<int> menuItems = List<int>.generate(4, (int i) => i);
+    final findDropdownMenu = find.byType(ListView);
+
+    List<DropdownItem<int>> buildItems() {
+      return menuItems.map((int item) {
+        return DropdownItem<int>(
+          value: item,
+          child: Text(item.toString()),
+        );
+      }).toList();
+    }
+
+    testWidgets(
+      'barrierBlocksInteraction false: outside control receives tap and menu closes',
+      (WidgetTester tester) async {
+        int outsideTaps = 0;
+        final valueListenable = ValueNotifier(menuItems.first);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: DropdownButton2<int>(
+                      barrierBlocksInteraction: false,
+                      valueListenable: valueListenable,
+                      items: buildItems(),
+                      onChanged: (_) {},
+                    ),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => outsideTaps++,
+                    child: const Text('Outside'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('${valueListenable.value}'));
+        await tester.pumpAndSettle();
+        expect(findDropdownMenu, findsOneWidget);
+
+        await tester.tap(find.text('Outside'));
+        await tester.pumpAndSettle();
+
+        expect(outsideTaps, 1);
+        expect(findDropdownMenu, findsNothing);
+      },
+    );
+
+    testWidgets(
+      'barrierBlocksInteraction true: tapping scaffold outside menu dismisses',
+      (WidgetTester tester) async {
+        final valueListenable = ValueNotifier(menuItems.first);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.topLeft,
+                child: DropdownButton2<int>(
+                  valueListenable: valueListenable,
+                  items: buildItems(),
+                  onChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('${valueListenable.value}'));
+        await tester.pumpAndSettle();
+        expect(findDropdownMenu, findsOneWidget);
+
+        // Bottom-right of the 800x600 test surface is outside the open menu.
+        await tester.tapAt(const Offset(780, 580));
+        await tester.pumpAndSettle();
+
+        expect(findDropdownMenu, findsNothing);
+      },
+    );
+  });
 }

--- a/packages/dropdown_button2/test/dropdown_button2_test.dart
+++ b/packages/dropdown_button2/test/dropdown_button2_test.dart
@@ -22,10 +22,6 @@ void main() {
         WidgetTester tester,
       ) async {
         final valueListenable = ValueNotifier(menuItems.first);
-        final findDropdownButtonText = find.descendant(
-          of: findDropdownButton,
-          matching: find.text('${valueListenable.value}'),
-        );
         final findSelectedMenuItemText = find.descendant(
           of: findDropdownMenu,
           matching: find.text('${valueListenable.value}'),
@@ -53,7 +49,7 @@ void main() {
         expect(findDropdownMenu, findsNothing);
         expect(buttonFocusNode.hasFocus, isFalse);
 
-        await tester.tap(findDropdownButtonText);
+        await tester.tap(findDropdownButton);
         await tester.pumpAndSettle();
 
         expect(findDropdownMenu, findsOneWidget);
@@ -65,10 +61,6 @@ void main() {
 
       testWidgets('button should stay highlighted when menu closes', (WidgetTester tester) async {
         final valueListenable = ValueNotifier(menuItems.first);
-        final findDropdownButtonText = find.descendant(
-          of: findDropdownButton,
-          matching: find.text('${valueListenable.value}'),
-        );
         final findSelectedMenuItemText = find.descendant(
           of: findDropdownMenu,
           matching: find.text('${valueListenable.value}'),
@@ -95,7 +87,7 @@ void main() {
 
         expect(buttonFocusNode.hasFocus, isFalse);
 
-        await tester.tap(findDropdownButtonText);
+        await tester.tap(findDropdownButton);
         await tester.pumpAndSettle();
 
         expect(buttonFocusNode.hasFocus, isTrue);
@@ -495,6 +487,8 @@ void main() {
     () {
       final List<int> menuItems = List<int>.generate(4, (int index) => index);
 
+      final findDropdownButton = find.byType(DropdownButton2<int>);
+
       List<DropdownItem<int>> buildItems() {
         return menuItems.map<DropdownItem<int>>((int item) {
           return DropdownItem<int>(
@@ -537,7 +531,7 @@ void main() {
           );
 
           // Open the menu.
-          await tester.tap(find.text('${valueListenable.value}'));
+          await tester.tap(findDropdownButton);
           await tester.pumpAndSettle();
 
           // While the menu is open, BlockSemantics in ModalBarrier blocks the
@@ -682,12 +676,14 @@ void main() {
     },
   );
 
-  group('barrierBlocksInteraction', () {
+  group('Modal Barrier', () {
     final List<int> menuItems = List<int>.generate(4, (int i) => i);
+
+    final findDropdownButton = find.byType(DropdownButton2<int>);
     final findDropdownMenu = find.byType(ListView);
 
     List<DropdownItem<int>> buildItems() {
-      return menuItems.map((int item) {
+      return menuItems.map<DropdownItem<int>>((int item) {
         return DropdownItem<int>(
           value: item,
           child: Text(item.toString()),
@@ -696,24 +692,21 @@ void main() {
     }
 
     testWidgets(
-      'barrierBlocksInteraction false: outside control receives tap and menu closes',
+      'outside tap should dismiss menu and not pass through '
+      'when barrierDismissible and barrierBlocksInteraction are true (default)',
       (WidgetTester tester) async {
-        int outsideTaps = 0;
         final valueListenable = ValueNotifier(menuItems.first);
+        int outsideTaps = 0;
 
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
               body: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Expanded(
-                    child: DropdownButton2<int>(
-                      barrierBlocksInteraction: false,
-                      valueListenable: valueListenable,
-                      items: buildItems(),
-                      onChanged: (_) {},
-                    ),
+                  DropdownButton2<int>(
+                    valueListenable: valueListenable,
+                    items: buildItems(),
+                    onChanged: (_) {},
                   ),
                   ElevatedButton(
                     onPressed: () => outsideTaps++,
@@ -725,8 +718,53 @@ void main() {
           ),
         );
 
-        await tester.tap(find.text('${valueListenable.value}'));
+        await tester.tap(findDropdownButton);
         await tester.pumpAndSettle();
+
+        expect(outsideTaps, 0);
+        expect(findDropdownMenu, findsOneWidget);
+
+        // The barrier absorbs the tap; warnIfMissed silences the hit-test warning.
+        await tester.tap(find.text('Outside'), warnIfMissed: false);
+        await tester.pumpAndSettle();
+
+        expect(outsideTaps, 0);
+        expect(findDropdownMenu, findsNothing);
+      },
+    );
+
+    testWidgets(
+      'outside tap should dismiss menu and pass through '
+      'when barrierDismissible is true (default) and barrierBlocksInteraction is false',
+      (WidgetTester tester) async {
+        final valueListenable = ValueNotifier(menuItems.first);
+        int outsideTaps = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: [
+                  DropdownButton2<int>(
+                    barrierBlocksInteraction: false,
+                    valueListenable: valueListenable,
+                    items: buildItems(),
+                    onChanged: (_) {},
+                  ),
+                  ElevatedButton(
+                    onPressed: () => outsideTaps++,
+                    child: const Text('Outside'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(findDropdownButton);
+        await tester.pumpAndSettle();
+
+        expect(outsideTaps, 0);
         expect(findDropdownMenu, findsOneWidget);
 
         await tester.tap(find.text('Outside'));
@@ -738,34 +776,157 @@ void main() {
     );
 
     testWidgets(
-      'barrierBlocksInteraction true: tapping scaffold outside menu dismisses',
+      'outside tap should not dismiss menu or pass through '
+      'when barrierDismissible is false and barrierBlocksInteraction is true (default)',
+      (WidgetTester tester) async {
+        final valueListenable = ValueNotifier(menuItems.first);
+        int outsideTaps = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: [
+                  DropdownButton2<int>(
+                    barrierDismissible: false,
+                    valueListenable: valueListenable,
+                    items: buildItems(),
+                    onChanged: (_) {},
+                  ),
+                  ElevatedButton(
+                    onPressed: () => outsideTaps++,
+                    child: const Text('Outside'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(findDropdownButton);
+        await tester.pumpAndSettle();
+
+        expect(outsideTaps, 0);
+        expect(findDropdownMenu, findsOneWidget);
+
+        await tester.tap(find.text('Outside'), warnIfMissed: false);
+        await tester.pumpAndSettle();
+
+        expect(outsideTaps, 0);
+        expect(findDropdownMenu, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'outside tap should not dismiss menu but pass through '
+      'when barrierDismissible and barrierBlocksInteraction are false',
+      (WidgetTester tester) async {
+        final valueListenable = ValueNotifier(menuItems.first);
+        int outsideTaps = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Row(
+                children: [
+                  DropdownButton2<int>(
+                    barrierDismissible: false,
+                    barrierBlocksInteraction: false,
+                    valueListenable: valueListenable,
+                    items: buildItems(),
+                    onChanged: (_) {},
+                  ),
+                  ElevatedButton(
+                    onPressed: () => outsideTaps++,
+                    child: const Text('Outside'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(findDropdownButton);
+        await tester.pumpAndSettle();
+
+        expect(outsideTaps, 0);
+        expect(findDropdownMenu, findsOneWidget);
+
+        await tester.tap(find.text('Outside'));
+        await tester.pumpAndSettle();
+
+        expect(outsideTaps, 1);
+        expect(findDropdownMenu, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'menu should close without re-opening on anchor-button tap '
+      'when barrierDismissible is true (default) and barrierBlocksInteraction is false',
       (WidgetTester tester) async {
         final valueListenable = ValueNotifier(menuItems.first);
 
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
-              body: Align(
-                alignment: Alignment.topLeft,
-                child: DropdownButton2<int>(
-                  valueListenable: valueListenable,
-                  items: buildItems(),
-                  onChanged: (_) {},
-                ),
+              body: DropdownButton2<int>(
+                barrierBlocksInteraction: false,
+                valueListenable: valueListenable,
+                items: buildItems(),
+                onChanged: (_) {},
               ),
             ),
           ),
         );
 
-        await tester.tap(find.text('${valueListenable.value}'));
+        await tester.tap(findDropdownButton);
         await tester.pumpAndSettle();
+
         expect(findDropdownMenu, findsOneWidget);
 
-        // Bottom-right of the 800x600 test surface is outside the open menu.
-        await tester.tapAt(const Offset(780, 580));
+        await tester.tap(findDropdownButton);
         await tester.pumpAndSettle();
 
+        // Barrier intercepts the anchor-button tap, and barrierDismissible (true) closes the menu.
         expect(findDropdownMenu, findsNothing);
+      },
+    );
+
+    testWidgets(
+      'menu should not close on anchor-button tap '
+      'when barrierDismissible and barrierBlocksInteraction are false',
+      (WidgetTester tester) async {
+        final valueListenable = ValueNotifier(menuItems.first);
+        int stateChanges = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownButton2<int>(
+                barrierDismissible: false,
+                barrierBlocksInteraction: false,
+                onMenuStateChange: (_) => stateChanges++,
+                valueListenable: valueListenable,
+                items: buildItems(),
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(findDropdownButton);
+        await tester.pumpAndSettle();
+
+        expect(stateChanges, 1);
+        expect(findDropdownMenu, findsOneWidget);
+
+        await tester.tap(findDropdownButton);
+        await tester.pumpAndSettle();
+
+        // Menu's route stays active (no close/re-open).
+        expect(stateChanges, 1);
+        // Barrier intercepts the anchor-button tap, and barrierDismissible (false) keeps menu open.
+        expect(findDropdownMenu, findsOneWidget);
       },
     );
   });


### PR DESCRIPTION
## Summary

- Adds a new optional flag `barrierBlocksInteraction` to `DropdownButton2` and `DropdownButtonFormField2` (default: `true` to preserve existing behavior).
- When set to `false`, outside taps can pass through to underlying widgets while still dismissing the currently open dropdown.

## Motivation

Our use case is a web form with several multi-select dropdowns in a row.
Today, after selecting values in the first dropdown, opening the next dropdown requires two clicks: first click closes the currently open dropdown, second click opens the next one.
This repeats for each dropdown and feels cumbersome.
With this feature, users can immediately switch between dropdowns in one click, which improves flow for multi-select-heavy forms.

https://github.com/user-attachments/assets/0a58f56c-3aee-45ee-bc71-00eec5443391

https://github.com/user-attachments/assets/bd2a9dbf-678c-40e0-8dd4-4d9aac4e0c66

Also resolves #62 