### PR TITLE
Re-lay out dropdown menu on ancestor scroll

### DIFF
--- a/packages/dropdown_button2/CHANGELOG.md
+++ b/packages/dropdown_button2/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `forceErrorText` support for DropdownButtonFormField2 [Flutter core].
 - Add ARIA menu roles to menu-related widgets for accessibility [Flutter core].
 - Add `anchoredMinHeight` to keep the menu anchored to the button and shrink to fit when possible, closes #429.
+- Re-lay out dropdown menu on ancestor scroll.
 
 ## 3.0.0
 

--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -428,6 +428,11 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBin
   // update its position if DropdownButton's position has changed, as when keyboard open.
   final ValueNotifier<Rect?> _buttonRect = ValueNotifier<Rect?>(null);
 
+  // Ancestor scroll positions we listen to while the menu is open, so the menu
+  // re-lays out as the anchor scrolls (re-evaluates its position and preferred height).
+  // Walks all ancestors so nested scrollables are supported.
+  final List<ScrollPosition> _ancestorScrollPositions = [];
+
   // Only used if needed to create _internalNode.
   FocusNode _createFocusNode() {
     return FocusNode(debugLabel: '${widget.runtimeType}');
@@ -492,6 +497,20 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBin
     _dropdownRoute?._dismiss();
     _dropdownRoute = null;
     _lastOrientation = null;
+    _removeAncestorScrollListeners();
+  }
+
+  void _removeAncestorScrollListeners() {
+    for (final position in _ancestorScrollPositions) {
+      position.removeListener(_handleAncestorScroll);
+    }
+    _ancestorScrollPositions.clear();
+  }
+
+  void _handleAncestorScroll() {
+    if (_buttonRectKey.currentContext != null) {
+      _buttonRect.value = _getButtonRect();
+    }
   }
 
   @override
@@ -680,6 +699,13 @@ class _DropdownButton2State<T> extends State<DropdownButton2<T>> with WidgetsBin
     final items = widget.items!;
     final separator = widget.dropdownSeparator;
     _buttonRect.value = _getButtonRect();
+
+    ScrollableState? scrollable = Scrollable.maybeOf(context);
+    while (scrollable != null) {
+      _ancestorScrollPositions.add(scrollable.position);
+      scrollable.position.addListener(_handleAncestorScroll);
+      scrollable = Scrollable.maybeOf(scrollable.context);
+    }
 
     assert(_dropdownRoute == null);
     _dropdownRoute = _DropdownRoute<T>(


### PR DESCRIPTION
## Summary

Tracks all ancestor `Scrollable` widgets while the dropdown menu is open so the menu re-lays out (re-evaluates its position and preferred height) when the button's position shifts.

Without this, once the menu is open, an ancestor can scroll and the menu stays frozen on its open-time layout.

## Implementation

On menu open, walks up via `Scrollable.maybeOf` (same pattern `Scrollable.ensureVisible` uses) and subscribes to every ancestor `ScrollableState.position`. On scroll, refreshes `_buttonRect`, and the existing `ValueListenableBuilder` rebuild re-runs layout. Listeners removed on menu close.

## Related

Prerequisite for #428 (`barrierBlocksInteraction`). With that flag set to `false`, users can scroll while the menu is open, which is where this issue becomes visible.