### PR TITLE
Fix InputDecorator paint matcher after drawPath→paintInterior change

### DIFF
--- a/packages/dropdown_button2/test/dropdown_button2_test.dart
+++ b/packages/dropdown_button2/test/dropdown_button2_test.dart
@@ -187,7 +187,7 @@ void main() {
         ).colorScheme.surfaceContainerHighest;
         expect(
           findInputDecoratorBorderPainter(),
-          paints..path(style: PaintingStyle.fill, color: defaultBorderColor),
+          paints..rrect(style: PaintingStyle.fill, color: defaultBorderColor),
         );
 
         // Replace focusNode and request focus.
@@ -199,7 +199,7 @@ void main() {
         await tester.pump(); // Wait for requestFocus to take effect.
         expect(
           findInputDecoratorBorderPainter(),
-          paints..path(style: PaintingStyle.fill, color: const Color(0xff00ff00)),
+          paints..rrect(style: PaintingStyle.fill, color: const Color(0xff00ff00)),
         );
 
         // Replace focusNode and request focus.
@@ -212,7 +212,7 @@ void main() {
         await tester.pump(); // Wait for unfocus to take effect.
         expect(
           findInputDecoratorBorderPainter(),
-          paints..path(style: PaintingStyle.fill, color: defaultBorderColor),
+          paints..rrect(style: PaintingStyle.fill, color: defaultBorderColor),
         );
       });
 


### PR DESCRIPTION
## Summary

`UnderlineInputBorder` now paints its filled background via `ShapeBorder.paintInterior` (which lowers to `drawRRect` for rounded rects) instead of `Canvas.drawPath(getOuterPath(...))`. Visual output is identical; only the recorded canvas call changes, so `paints..path(...)` no longer matches.

Replace `paints..path(...)` with `paints..rrect(...)` for the InputDecorator filled-background assertions in tests.
