### PR TITLE
Migrate to standalone UI packages

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,6 +20,13 @@ analyzer:
     - "**/*.pb.dart"
     - "**/*.g.dart"
     - "**/*.mocks.dart" # Mockito @GenerateMocks
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 formatter:
   # Preserve trailing commas until Dart formatting improves

--- a/packages/dropdown_button2/example/custom_dropdown_button2.dart
+++ b/packages/dropdown_button2/example/custom_dropdown_button2.dart
@@ -1,6 +1,6 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class CustomDropdownButton2 extends StatelessWidget {
   const CustomDropdownButton2({

--- a/packages/dropdown_button2/example/example.dart
+++ b/packages/dropdown_button2/example/example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() {
   runApp(const MyApp());

--- a/packages/dropdown_button2/lib/src/dropdown_button2.dart
+++ b/packages/dropdown_button2/lib/src/dropdown_button2.dart
@@ -10,8 +10,8 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'seperated_sliver_child_builder_delegate.dart';
 

--- a/packages/dropdown_button2/lib/src/seperated_sliver_child_builder_delegate.dart
+++ b/packages/dropdown_button2/lib/src/seperated_sliver_child_builder_delegate.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 
 /// A specialized [SliverChildBuilderDelegate] that builds children for slivers
 /// with separators between them.

--- a/packages/dropdown_button2/pubspec.yaml
+++ b/packages/dropdown_button2/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dropdown_button2
 description: Flutter's core Dropdown Button widget with a steady dropdown menu and many other options you can customize to your needs.
-version: 3.1.0
+version: 4.0.0
 repository: https://github.com/AhmedLSayed9/dropdown_button2
 issue_tracker: https://github.com/AhmedLSayed9/dropdown_button2/issues
 
@@ -13,6 +13,8 @@ dependencies:
     sdk: flutter
   meta: ^1.9.1
 
+  material_ui: 1.0.0
+  cupertino_ui: 1.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/dropdown_button2/pubspec.yaml
+++ b/packages/dropdown_button2/pubspec.yaml
@@ -5,16 +5,16 @@ repository: https://github.com/AhmedLSayed9/dropdown_button2
 issue_tracker: https://github.com/AhmedLSayed9/dropdown_button2/issues
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ">=3.13.0 <4.0.0"
+  flutter: ">=3.47.0"
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
 
-  material_ui: 1.0.0
-  cupertino_ui: 1.0.0
+  material_ui: ^1.0.0
+  cupertino_ui: ^1.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/dropdown_button2/test/dropdown_button2_test.dart
+++ b/packages/dropdown_button2/test/dropdown_button2_test.dart
@@ -1,8 +1,8 @@
 import 'dart:ui';
 
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 
 Finder findInputDecoratorBorderPainter() {
   return find.descendant(

--- a/packages/dropdown_button2_test/analysis_options.yaml
+++ b/packages/dropdown_button2_test/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../analysis_options.yaml
 
 linter:

--- a/packages/dropdown_button2_test/lib/src/few_styling_example.dart
+++ b/packages/dropdown_button2_test/lib/src/few_styling_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class FewStylingExample extends StatefulWidget {
   const FewStylingExample({super.key});

--- a/packages/dropdown_button2_test/lib/src/form_field_example.dart
+++ b/packages/dropdown_button2_test/lib/src/form_field_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class FormFieldExample extends StatefulWidget {
   const FormFieldExample({super.key});

--- a/packages/dropdown_button2_test/lib/src/multi_select_example.dart
+++ b/packages/dropdown_button2_test/lib/src/multi_select_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class MultiSelectExample extends StatefulWidget {
   const MultiSelectExample({super.key});

--- a/packages/dropdown_button2_test/lib/src/popup_icon_example.dart
+++ b/packages/dropdown_button2_test/lib/src/popup_icon_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PopupIconExample extends StatefulWidget {
   const PopupIconExample({super.key});

--- a/packages/dropdown_button2_test/lib/src/popup_image_example.dart
+++ b/packages/dropdown_button2_test/lib/src/popup_image_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class PopupImageExample extends StatefulWidget {
   const PopupImageExample({super.key});

--- a/packages/dropdown_button2_test/lib/src/search_example.dart
+++ b/packages/dropdown_button2_test/lib/src/search_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class SearchExample extends StatefulWidget {
   const SearchExample({super.key});

--- a/packages/dropdown_button2_test/lib/src/simple_example.dart
+++ b/packages/dropdown_button2_test/lib/src/simple_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class SimpleExample extends StatefulWidget {
   const SimpleExample({super.key});

--- a/packages/dropdown_button2_test/lib/src/with_separators_example.dart
+++ b/packages/dropdown_button2_test/lib/src/with_separators_example.dart
@@ -1,5 +1,5 @@
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class WithSeparatorsExample extends StatefulWidget {
   const WithSeparatorsExample({super.key});

--- a/packages/dropdown_button2_test/pubspec.yaml
+++ b/packages/dropdown_button2_test/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   dropdown_button2:
     path: ../dropdown_button2
 
+  material_ui: 1.0.0
 dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_test:

--- a/packages/dropdown_button2_test/pubspec.yaml
+++ b/packages/dropdown_button2_test/pubspec.yaml
@@ -2,8 +2,8 @@ name: dropdown_button2_test
 publish_to: none
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ">=3.13.0 <4.0.0"
+  flutter: ">=3.47.0"
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
   dropdown_button2:
     path: ../dropdown_button2
 
-  material_ui: 1.0.0
+  material_ui: ^1.0.0
 dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_test:

--- a/packages/dropdown_button2_test/test/examples/test_app.dart
+++ b/packages/dropdown_button2_test/test/examples/test_app.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class TestApp extends StatelessWidget {
   const TestApp({required this.widget, super.key});

--- a/packages/dropdown_button2_test/test/utils/utils.dart
+++ b/packages/dropdown_button2_test/test/utils/utils.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:meta/meta.dart';
 
 import '../examples/test_app.dart';
 
-part 'widget_tester_utils.dart';
 part 'run_golden_tests.dart';
 part 'test_variants.dart';
+part 'widget_tester_utils.dart';


### PR DESCRIPTION
With Flutter 3.47 release, standalone [[material_ui](https://pub.dev/packages/material_ui)](https://pub.dev/packages/material_ui) and [[cupertino_ui](https://pub.dev/packages/cupertino_ui)](https://pub.dev/packages/cupertino_ui) packages are released.

> The original design libraries inside the core SDK are scheduled for formal deprecation in the upcoming Fall stable release in November. If you are migrating a package in the ecosystem, treat this move to the standalone packages as a major release.

Please consider upgrading this package to support this framework change